### PR TITLE
DEV-10 作業場所作成機能を追加

### DIFF
--- a/app/assets/stylesheets/admin/workshops.scss
+++ b/app/assets/stylesheets/admin/workshops.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin/workshops controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/admin/workshops.scss
+++ b/app/assets/stylesheets/admin/workshops.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the admin/workshops controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -10,8 +10,7 @@ module Admin
     def create
       @workshop = Workshop.new(workshop_params)
       if @workshop.save
-        redirect_to workshops_path
-        flash[:success] = t 'admin.flash.success', workshop: @workshop.name
+        redirect_to workshops_path, notice: t('action.created', model: '作業場所', name: @workshop.name)
       else
         render 'new'
       end

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  # 施設登録（管理者用）
+  class WorkshopsController < ApplicationController
+    def new
+      @workshop = Workshop.new
+    end
+
+    def create
+      @workshop = Workshop.new(workshop_params)
+      if @workshop.save
+        redirect_to workshops_path
+        flash[:success] = t 'admin.flash.success', workshop: @workshop.name
+      else
+        render 'new'
+      end
+    end
+
+    private
+
+    def workshop_params
+      params.require(:workshop).permit(:name, :category, :address, :wifi,
+                                       :seats_number, :opening_time, :price, :note, :station_id)
+    end
+  end
+end

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -10,7 +10,7 @@ module Admin
     def create
       @workshop = Workshop.new(workshop_params)
       if @workshop.save
-        redirect_to workshops_path, notice: t('action.created', model: '作業場所', name: @workshop.name)
+        redirect_to workshops_path, notice: t('action.created', model: Workshop.model_name.human, name: @workshop.name)
       else
         render 'new'
       end

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# 施設の登録・管理
+# 施設閲覧（ユーザー向け）
 class WorkshopsController < ApplicationController
   def index
     @workshops = Workshop.all

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -6,10 +6,8 @@ class Workshop < ApplicationRecord
   validates :name, presence: true
   validates :category, presence: true
   validates :address, presence: true
-  validates :wifi, presence: true
   validates :opening_time, presence: true
   validates :price, presence: true
-  validates :station_id, presence: true
 
   enum category: { coworking_space: 0, cafe: 1, other: 2 }
 end

--- a/app/views/admin/workshops/new.html.slim
+++ b/app/views/admin/workshops/new.html.slim
@@ -12,44 +12,44 @@ h1 作業場所作成
       th 項目
       th 登録内容
     tr
-      td 施設名称
+      td = Workshop.human_attribute_name(:name)
       td
         = form.text_field :name
     tr
-      td 住所
+      td = Workshop.human_attribute_name(:address)
       td
         = form.text_field :address
     tr
-      td 最寄駅
+      td = Workshop.human_attribute_name(:station)
       td
         = form.collection_select(:station_id, Station.all,
         :id, :name, include_blank: true)
     tr
-      td 業態
+      td = Workshop.human_attribute_name(:category)
       td
         = form.select :category,
         Workshop.categories_i18n.invert, include_blank: true
     tr
-      td wi-fi
+      td = Workshop.human_attribute_name(:wifi)
       td
         = form.radio_button :wifi, true
         div あり
         = form.radio_button :wifi, false
         div なし
     tr
-      td 席数
+      td = Workshop.human_attribute_name(:seats_number)
       td
         = form.number_field :seats_number, min: 1
     tr
-      td 営業時間
+      td = Workshop.human_attribute_name(:opening_time)
       td
         = form.text_field :opening_time
     tr
-      td 利用料
+      td = Workshop.human_attribute_name(:price)
       td
         = form.text_field :price
     tr
-      td 特徴
+      td = Workshop.human_attribute_name(:note)
       td
         = form.text_area :note
   = form.submit

--- a/app/views/admin/workshops/new.html.slim
+++ b/app/views/admin/workshops/new.html.slim
@@ -1,0 +1,55 @@
+h1 作業場所作成
+= form_with model: @workshop, url: admin_workshops_path, local: true do |form|
+
+  - if @workshop.errors.any?
+    ul
+      - @workshop.errors.full_messages.each do |message|
+        li
+          = message
+
+  table[border='1']
+    tr
+      th 項目
+      th 登録内容
+    tr
+      td 施設名称
+      td
+        = form.text_field :name
+    tr
+      td 住所
+      td
+        = form.text_field :address
+    tr
+      td 最寄駅
+      td
+        = form.collection_select(:station_id, Station.all,
+        :id, :name, include_blank: true)
+    tr
+      td 業態
+      td
+        = form.select :category,
+        Workshop.categories_i18n.invert, include_blank: true
+    tr
+      td wi-fi
+      td
+        = form.radio_button :wifi, true
+        div あり
+        = form.radio_button :wifi, false
+        div なし
+    tr
+      td 席数
+      td
+        = form.number_field :seats_number, min: 1
+    tr
+      td 営業時間
+      td
+        = form.text_field :opening_time
+    tr
+      td 利用料
+      td
+        = form.text_field :price
+    tr
+      td 特徴
+      td
+        = form.text_area :note
+  = form.submit

--- a/app/views/workshops/index.html.slim
+++ b/app/views/workshops/index.html.slim
@@ -1,3 +1,6 @@
+.admin
+  = flash[:success]
+  = link_to '施設登録', new_admin_workshop_path
 .title
   h1 SHIGOTOBA
 .search-field

--- a/app/views/workshops/index.html.slim
+++ b/app/views/workshops/index.html.slim
@@ -1,5 +1,5 @@
 .admin
-  = flash[:success]
+  = notice
   = link_to '施設登録', new_admin_workshop_path
 .title
   h1 SHIGOTOBA

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,9 +5,8 @@ ja:
         coworking_space: コワーキングスペース
         cafe: カフェ
         other: その他
-  admin:
-    flash:
-      success: 作業場所： %{workshop}を作成しました
+  action:
+    created: "%{model}： %{name}を作成しました"
   activerecord:
     models:
       workshop: 作業場所

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,3 +5,224 @@ ja:
         coworking_space: コワーキングスペース
         cafe: カフェ
         other: その他
+  admin:
+    flash:
+      success: 作業場所： %{workshop}を作成しました
+  activerecord:
+    models:
+      workshop: 作業場所
+    attributes:
+      workshop:
+        name: 施設名称
+        category: 業態
+        address: 住所
+        wifi: wi-fi
+        seats_number: 席数
+        opening_time: 営業時間
+        price: 利用料
+        note: 特徴
+        station: 最寄駅  
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,7 @@ Rails.application.routes.draw do
   root 'stations#index'
   resources :stations
   resources :workshops, only: [:index, :show]
+  namespace :admin do
+    resources :workshops, only: [:new, :create]
+  end
 end


### PR DESCRIPTION
closed #10 

【対応内容】 
・作業場所作成画面を追加する
・作成画面に遷移するリンクは一覧画面に用意すること
・urlはadmin/workshops/newとすること
・追加ボタン押下で作業場所が追加され一覧画面に遷移する
　一覧画面には「作業場所: ○○をを作成しました」とflashメッセージが表示される
　(flashの文言は自由だが文言はconfig/locales/ja.ymlを追加しそこに記載する)
・追加にvalidateで失敗した場合、validateメッセージが表示されること

【確認内容】
 ・作業場所がデータベースに登録できることを確認。
・作業場所登録直後にflashメッセージが表示されることを確認。
・作業場所登録に失敗した場合、バリデーションのエラーメッセージが表示されることを確認。

作成画面（登録失敗後）
![image](https://user-images.githubusercontent.com/60866281/76053980-64e88980-5fb2-11ea-9f4b-aa8b01b38221.png)

一覧画面（「新宿ドトール」を追加後）
![image](https://user-images.githubusercontent.com/60866281/76053986-6ade6a80-5fb2-11ea-8793-3c61018e6141.png)
