### PR TITLE
DEV-11 [管理側]作業場所一覧画面を作成する

### DIFF
--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 module Admin
-  # 施設登録（管理者用）
+  # 施設登録・管理（管理者用）
   class WorkshopsController < ApplicationController
+    def index
+      @workshops = Workshop.all.order('updated_at ASC')
+    end
+
     def new
       @workshop = Workshop.new
     end
@@ -10,7 +14,7 @@ module Admin
     def create
       @workshop = Workshop.new(workshop_params)
       if @workshop.save
-        redirect_to workshops_path, notice: t('action.created', model: Workshop.model_name.human, name: @workshop.name)
+        redirect_to admin_workshops_path, notice: t('action.created', model: Workshop.model_name.human, name: @workshop.name)
       else
         render 'new'
       end

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -4,7 +4,7 @@ module Admin
   # 施設登録・管理（管理者用）
   class WorkshopsController < ApplicationController
     def index
-      @workshops = Workshop.all.order('updated_at ASC')
+      @workshops = Workshop.order(:updated_at)
     end
 
     def new

--- a/app/views/admin/workshops/index.html.slim
+++ b/app/views/admin/workshops/index.html.slim
@@ -1,0 +1,41 @@
+header
+  = notice
+  = link_to '施設登録', new_admin_workshop_path
+.title
+  h1 作業場所一覧
+.workshops_field
+  - @workshops.each do |workshop|
+    div
+      div 情報更新日：#{workshop.updated_at.strftime('%Y年 %m月 %d日 %H時 %M分')}
+      table[border='1']
+        tr
+          th 項目
+          th 登録内容
+        tr
+          td = Workshop.human_attribute_name(:name)
+          td = workshop.name
+        tr
+          td = Workshop.human_attribute_name(:address)
+          td = workshop.address
+        tr
+          td = Workshop.human_attribute_name(:station)
+          td = workshop.station.name
+        tr
+          td = Workshop.human_attribute_name(:category)
+          td = workshop.category_i18n
+        tr
+          td = Workshop.human_attribute_name(:wifi)
+          td = workshop.wifi ? 'あり' : 'なし'
+        tr
+          td = Workshop.human_attribute_name(:seats_number)
+          td = workshop.seats_number.presence || '不明'
+        tr
+          td = Workshop.human_attribute_name(:opening_time)
+          td = workshop.opening_time
+        tr
+          td = Workshop.human_attribute_name(:price)
+          td = workshop.price
+        tr
+          td = Workshop.human_attribute_name(:note)
+          td = workshop.note
+      br

--- a/app/views/admin/workshops/new.html.slim
+++ b/app/views/admin/workshops/new.html.slim
@@ -1,5 +1,5 @@
 h1 作業場所作成
-= form_with model: @workshop, url: admin_workshops_path, local: true do |form|
+= form_with model: [:admin, @workshop], local: true do |form|
 
   - if @workshop.errors.any?
     ul

--- a/app/views/workshops/index.html.slim
+++ b/app/views/workshops/index.html.slim
@@ -1,6 +1,3 @@
-.admin
-  = notice
-  = link_to '施設登録', new_admin_workshop_path
 .title
   h1 SHIGOTOBA
 .search-field

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,6 @@ module Shigotoba
     config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
     # デフォルトのlocaleを日本語(:ja)にする
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   resources :stations
   resources :workshops, only: [:index, :show]
   namespace :admin do
-    resources :workshops, only: [:new, :create]
+    resources :workshops, only: [:index, :new, :create]
   end
 end


### PR DESCRIPTION
【対応内容】 
・管理者用の作業場所一覧画面を作成する
・作業場所作成後に作業場所一覧画面に遷移すること。
・urlはadmin/workshopsとすること
・全ての作業場所が表示されていること

【確認内容】
 ・登録した作業場所情報が一覧で表示されることを確認。
・作業場所作成後に作業場所一覧画面に遷移することを確認。

![image](https://user-images.githubusercontent.com/60866281/76176025-81730480-61f2-11ea-9602-94eab7a64983.png)

