### PR TITLE
DEV-13 [管理側]作業場所削除機能を追加する

### DIFF
--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -33,6 +33,12 @@ module Admin
       end
     end
 
+    def destroy
+      @workshop = Workshop.find(params[:id])
+      @workshop.destroy
+      redirect_to admin_workshops_path, notice: t('action.destroyed', model: Workshop.model_name.human, name: @workshop.name)
+    end
+
     private
 
     def workshop_params

--- a/app/views/admin/workshops/index.html.slim
+++ b/app/views/admin/workshops/index.html.slim
@@ -8,6 +8,7 @@ header
     div
       div 情報更新日：#{l(workshop.updated_at, format: :long)}
       = link_to '編集', edit_admin_workshop_path(workshop.id)
+      = link_to '削除', "/admin/workshops/#{workshop.id}", method: :delete
       table[border='1']
         tr
           th 項目

--- a/app/views/admin/workshops/index.html.slim
+++ b/app/views/admin/workshops/index.html.slim
@@ -8,7 +8,7 @@ header
     div
       div 情報更新日：#{l(workshop.updated_at, format: :long)}
       = link_to '編集', edit_admin_workshop_path(workshop.id)
-      = link_to '削除', "/admin/workshops/#{workshop.id}", method: :delete
+      = link_to '削除', admin_workshop_path(workshop.id), method: :delete
       table[border='1']
         tr
           th 項目

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,6 +8,7 @@ ja:
   action:
     created: "%{model}： %{name}を作成しました"
     updated: "%{model}： %{name}を編集しました"
+    destroyed: "%{model}： %{name}を削除しました"
   activerecord:
     models:
       workshop: 作業場所

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   resources :stations
   resources :workshops, only: [:index, :show]
   namespace :admin do
-    resources :workshops, only: [:index, :new, :create, :edit, :update]
+    resources :workshops, except: :show
   end
 end


### PR DESCRIPTION
closed #13 

# 対応内容
- 削除ボタンは一覧画面に用意すること
- 削除は作業場所全件削除ではなく指定の一つが削除できること
- 削除ボタン押下で作業場所が削除され「作業場所: ○○をを削除しました」とflashメッセージが表示される(flashの文言は自由だが文言はconfig/locales/ja.ymlに記載する)

# 確認内容
- 削除ボタンを押下すると一覧画面から対象の作業場所が削除されることを確認
- 削除直後にflashメッセージが表示されることを確認

# 画面
## 「横浜ドトール」を削除前
![image](https://user-images.githubusercontent.com/60866281/76192381-01b25d80-6225-11ea-91e4-9be2c4d98cc3.png)

## 「横浜ドトール」を削除後
![image](https://user-images.githubusercontent.com/60866281/76192453-332b2900-6225-11ea-9329-c4b84a29a34d.png)


