### PR TITLE
DEV-14 作業場所検索機能を追加

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -5,7 +5,6 @@ class WorkshopsController < ApplicationController
   def index
     @search_params = workshop_search_params
     @workshops = Workshop.search(@search_params)
-    # binding.pry
   end
 
   def show

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -3,10 +3,18 @@
 # 施設閲覧（ユーザー向け）
 class WorkshopsController < ApplicationController
   def index
-    @workshops = Workshop.all
+    @search_params = workshop_search_params
+    @workshops = Workshop.search(@search_params)
+    # binding.pry
   end
 
   def show
     @workshop = Workshop.find(params[:id])
+  end
+
+  private
+
+  def workshop_search_params
+    params.fetch(:search, {}).permit(:station_id, :category, :wifi)
   end
 end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -10,4 +10,15 @@ class Workshop < ApplicationRecord
   validates :price, presence: true
 
   enum category: { coworking_space: 0, cafe: 1, other: 2 }
+
+  scope :search, lamda(search_params) do
+    return if search_params.blank?
+
+    station_id_is(search_params[:station_id])
+      .category_is(search_params[:category])
+      .wifi_is(search_params[:wifi])
+  end
+  scope :station_id_is, ->(station_id) { station_id.present? ? where(station_id: station_id) : all }
+  scope :category_is, ->(category) { category.present? ? where(category: category) : all }
+  scope :wifi_is, ->(wifi) { wifi == true ? where(wifi: true) : all }
 end

--- a/app/views/admin/workshops/index.html.slim
+++ b/app/views/admin/workshops/index.html.slim
@@ -7,8 +7,8 @@ header
   - @workshops.each do |workshop|
     div
       div 情報更新日：#{l(workshop.updated_at, format: :long)}
-      = link_to '編集', edit_admin_workshop_path(workshop.id)
-      = link_to '削除', admin_workshop_path(workshop.id), method: :delete
+      = link_to '編集', edit_admin_workshop_path(workshop)
+      = link_to '削除', admin_workshop_path(workshop), method: :delete
       table[border='1']
         tr
           th 項目

--- a/app/views/workshops/index.html.slim
+++ b/app/views/workshops/index.html.slim
@@ -1,6 +1,26 @@
 .title
   h1 SHIGOTOBA
+
 .search-field
+  = form_with scope: :search, url: workshops_path,
+    method: :get, local: true do |form|
+    strong 絞り込み条件
+    div
+      = form.label :station_id, Workshop.human_attribute_name(:station)
+      = form.collection_select(:station_id, Station.all, :id, :name,
+        selected: @search_params[:station_id], include_blank: '選択しない')
+    div
+      = form.label :category, Workshop.human_attribute_name(:category)
+      = form.select :category, Workshop.categories_i18n.invert,
+        selected: @search_params[:category], include_blank: '選択しない'
+    strong こだわり条件
+    div
+      = form.label :wifi, "#{Workshop.human_attribute_name(:wifi)}あり"
+      = form.check_box :wifi, { checked: @search_params[:wifi] == 'true' },
+        true, false
+    div
+      = form.submit '検索する'
+
 .workshops-field
   - @workshops.each do |workshop|
     div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Rails.application.routes.draw do
   root 'stations#index'
   resources :stations
-  resources :workshops, only: [:index, :show] do
-    get :search, on: :collection
-  end
+  resources :workshops, only: [:index, :show]
   namespace :admin do
     resources :workshops, except: :show
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   root 'stations#index'
   resources :stations
-  resources :workshops, only: [:index, :show]
+  resources :workshops, only: [:index, :show] do
+    get :search, on: :collection
+  end
   namespace :admin do
     resources :workshops, except: :show
   end


### PR DESCRIPTION
closed #14 

# 対応内容
- ユーザーが使う作業場所一覧画面にて検索ボタンを追加する
- 検索ボタン押下で指定された項目で絞り込まれること
- 複数項目で検索ができること
- 検索機能を実装する際にgemは使用しないこと

# 確認内容
- 検索ボタン押下で指定された項目で絞り込まれることを確認
- 検索ボタン押下後に絞り込み条件が保持されることを確認

# 画面
## 「最寄駅：町田」で絞り込み
![image](https://user-images.githubusercontent.com/60866281/76377368-0c3c3680-638e-11ea-8f94-6acae476abc3.png)

## 「最寄駅：町田」「業態：カフェ」で絞り込み
![image](https://user-images.githubusercontent.com/60866281/76377398-2118ca00-638e-11ea-9cca-7c1b09fa248b.png)

## 「最寄駅：町田」「業態：カフェ」「wifiあり」で絞り込み
![image](https://user-images.githubusercontent.com/60866281/76377485-5ae9d080-638e-11ea-8dd0-29252e97d3e6.png)

## 「業態：カフェ」で絞り込み
![image](https://user-images.githubusercontent.com/60866281/76377615-b1efa580-638e-11ea-806b-45682bc64636.png)
