### PR TITLE
DEV-15 [管理側]作業場所一覧画面にページネート機能を追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,3 +49,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'slim-rails'
 gem 'enum_help'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,18 @@ GEM
     jaro_winkler (1.5.4)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.0)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.0)
+      kaminari-activerecord (= 1.2.0)
+      kaminari-core (= 1.2.0)
+    kaminari-actionview (1.2.0)
+      actionview
+      kaminari-core (= 1.2.0)
+    kaminari-activerecord (1.2.0)
+      activerecord
+      kaminari-core (= 1.2.0)
+    kaminari-core (1.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -217,6 +229,7 @@ DEPENDENCIES
   byebug
   enum_help
   jbuilder (~> 2.7)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4)
   pry-rails

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -4,7 +4,7 @@ module Admin
   # 施設登録・管理（管理者用）
   class WorkshopsController < ApplicationController
     def index
-      @workshops = Workshop.order(:updated_at)
+      @workshops = Workshop.page(params[:page]).per(20).order('updated_at DESC')
     end
 
     def new

--- a/app/views/admin/workshops/index.html.slim
+++ b/app/views/admin/workshops/index.html.slim
@@ -41,3 +41,4 @@ header
           td = Workshop.human_attribute_name(:note)
           td = workshop.note
       br
+= paginate @workshops


### PR DESCRIPTION
closed #15 

# 対応内容
- 管理側の作業場所一覧画面にページネート機能を追加する
- gemはkaminariを使う
- 20件ごとにページネートできること
- 並び順を最新順に変更（追加した作業場所が１ページ目上部で確認できるようにするため）

# 確認内容
- 管理側の作業場所一覧画面において、作業場所が21件目以降２ページ目に表示されること。

# 画面
## １ページ目の下部
![image](https://user-images.githubusercontent.com/60866281/76579903-3bc77c00-6511-11ea-8c46-0a8bf2d59c82.png)


## ２ページ目の下部
![image](https://user-images.githubusercontent.com/60866281/76579908-3d913f80-6511-11ea-89f2-ec84c5b619b2.png)
