### PR TITLE
DEV-17 デザイン当て

### DIFF
--- a/.slim-lint.yml
+++ b/.slim-lint.yml
@@ -1,0 +1,3 @@
+linters:
+  LineLength:
+    max: 200

--- a/app/assets/stylesheets/workshop.css
+++ b/app/assets/stylesheets/workshop.css
@@ -1,0 +1,3 @@
+.bg-snow {
+  background-color:snow;
+}

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -5,9 +5,13 @@ class WorkshopsController < ApplicationController
   def index
     @search_params = workshop_search_params
     @workshops = search(workshop_search_params)
+    @stations = Station.all
   end
 
   def show
+    @search_params = workshop_search_params
+    @workshops = search(workshop_search_params)
+    @stations = Station.all
     @workshop = Workshop.find(params[:id])
   end
 

--- a/app/views/admin/stations/index.html.slim
+++ b/app/views/admin/stations/index.html.slim
@@ -1,5 +1,9 @@
-h1 トップページ
-= link_to '駅登録', new_admin_station_path
-br
-- @stations.each do |station|
-  = link_to station.name, admin_station_path(station)
+.container
+  .div
+    h1 駅管理ページ
+  .my-3
+    = link_to '新規登録', new_admin_station_path, class: 'h3'
+  .div
+    h3.my-2 登録済み一覧
+    - @stations.each do |station|
+      .div = link_to station.name, admin_station_path(station)

--- a/app/views/admin/stations/index.html.slim
+++ b/app/views/admin/stations/index.html.slim
@@ -1,9 +1,9 @@
 .container
-  .div
+  div
     h1 駅管理ページ
   .my-3
     = link_to '新規登録', new_admin_station_path, class: 'h3'
-  .div
+  div
     h3.my-2 登録済み一覧
     - @stations.each do |station|
-      .div = link_to station.name, admin_station_path(station)
+      div = link_to station.name, admin_station_path(station)

--- a/app/views/admin/workshops/index.html.slim
+++ b/app/views/admin/workshops/index.html.slim
@@ -1,44 +1,50 @@
-header
-  = notice
-  = link_to '施設登録', new_admin_workshop_path
-.title
-  h1 作業場所一覧
-.workshops_field
-  - @workshops.each do |workshop|
-    div
-      div 情報更新日：#{l(workshop.updated_at, format: :long)}
-      = link_to '編集', edit_admin_workshop_path(workshop)
-      = link_to '削除', admin_workshop_path(workshop), method: :delete
-      table[border='1']
-        tr
-          th 項目
-          th 登録内容
-        tr
-          td = Workshop.human_attribute_name(:name)
-          td = workshop.name
-        tr
-          td = Workshop.human_attribute_name(:address)
-          td = workshop.address
-        tr
-          td = Workshop.human_attribute_name(:station)
-          td = workshop.station.name
-        tr
-          td = Workshop.human_attribute_name(:category)
-          td = workshop.category_i18n
-        tr
-          td = Workshop.human_attribute_name(:wifi)
-          td = workshop.wifi ? 'あり' : 'なし'
-        tr
-          td = Workshop.human_attribute_name(:seats_number)
-          td = workshop.seats_number.presence || '不明'
-        tr
-          td = Workshop.human_attribute_name(:opening_time)
-          td = workshop.opening_time
-        tr
-          td = Workshop.human_attribute_name(:price)
-          td = workshop.price
-        tr
-          td = Workshop.human_attribute_name(:note)
-          td = workshop.note
-      br
-= paginate @workshops
+.pl-3
+  .row
+    h3 = notice
+
+  .row
+    h1 施設管理ページ
+
+  .row.my-3
+    = link_to '新規登録', new_admin_workshop_path, class: 'h3'
+
+  .row.workshops_field
+    h3.my-2 登録済み施設一覧
+    .div
+      .div.py-3.border-bottom
+        .row
+          .col-2 編集・削除
+          .col-2 更新日
+        .row
+          .col-1 = Workshop.human_attribute_name(:id)
+          .col-1 = Workshop.human_attribute_name(:name)
+          .col-1 = Workshop.human_attribute_name(:station)
+          .col-1 = Workshop.human_attribute_name(:category)
+          .col-1 = Workshop.human_attribute_name(:adress)
+          .col-1 = Workshop.human_attribute_name(:wifi)
+          .col-1 = Workshop.human_attribute_name(:seats_number)
+          .col-1 = Workshop.human_attribute_name(:opening_time)
+          .col-1 = Workshop.human_attribute_name(:price)
+          .col-3 = Workshop.human_attribute_name(:note)
+      - @workshops.each do |workshop|
+        .div.py-3.border-bottom
+          .row.mb-2
+            .col-2
+              .row.m-0
+                = link_to '編集', edit_admin_workshop_path(workshop)
+                div ・
+                = link_to '削除', admin_workshop_path(workshop), method: :delete
+            .col-2 = l(workshop.updated_at, format: :long)
+          .row
+            .col-1 = workshop.id
+            .col-1 = workshop.name
+            .col-1 = workshop.station.name
+            .col-1 = workshop.category_i18n
+            .col-1 = workshop.address
+            .col-1 = workshop.wifi ? 'あり' : 'なし'
+            .col-1 = workshop.seats_number.presence || '不明'
+            .col-1 = workshop.opening_time
+            .col-1 = workshop.price
+            .col-3 = workshop.note.presence || '登録なし'
+
+  = paginate @workshops

--- a/app/views/admin/workshops/index.html.slim
+++ b/app/views/admin/workshops/index.html.slim
@@ -10,8 +10,8 @@
 
   .row.workshops_field
     h3.my-2 登録済み施設一覧
-    .div
-      .div.py-3.border-bottom
+    div
+      .py-3.border-bottom
         .row
           .col-2 編集・削除
           .col-2 更新日
@@ -27,7 +27,7 @@
           .col-1 = Workshop.human_attribute_name(:price)
           .col-3 = Workshop.human_attribute_name(:note)
       - @workshops.each do |workshop|
-        .div.py-3.border-bottom
+        .py-3.border-bottom
           .row.mb-2
             .col-2
               .row.m-0

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,6 +2,8 @@ doctype html
 html
   head
     meta content='text/html; charset=UTF-8' http-equiv='Content-Type' /
+    link[rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
+    integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous"]
     title Shigotoba
     = csrf_meta_tags
     = csp_meta_tag
@@ -10,3 +12,4 @@ html
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
     = yield
+    script[src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"]

--- a/app/views/workshops/_search_field.html.slim
+++ b/app/views/workshops/_search_field.html.slim
@@ -1,0 +1,19 @@
+.col-3.px-3
+  = form_with scope: :search, url: workshops_path,
+    method: :get, local: true do |form|
+    h4 絞り込み条件
+    .mt-5.mb-3
+      = form.label :station_id, Workshop.human_attribute_name(:station)
+      = form.collection_select(:station_id, Station.all, :id, :name,
+        { selected: search_params[:station_id], include_blank: '選択しない' }, class: 'form-control')
+    .mt-5.mb-5
+      = form.label :category, Workshop.human_attribute_name(:category)
+      = form.select :category, Workshop.categories_i18n.invert,
+        { selected: search_params[:category], include_blank: '選択しない' }, class: 'form-control'
+    h4 こだわり条件
+    .mt-5.mb-5
+      = form.label :wifi, "#{Workshop.human_attribute_name(:wifi)}あり", class: 'form-check-label mr-4'
+      = form.check_box :wifi, { checked: search_params[:wifi] == 'true', class: 'form-check-input' },
+        true, false
+    .mt-5.mb-5
+      = form.submit value: '検索する', class: 'btn btn-success float-right'

--- a/app/views/workshops/_title.html.slim
+++ b/app/views/workshops/_title.html.slim
@@ -1,0 +1,10 @@
+.div
+  .row
+    = link_to 'SHIGOTOBA', root_path, class: 'h1 pt-3 text-reset text-decoration-none'
+  .row
+    .col-12
+      .float-right
+        p コワーキングスペース、カフェなどの作業場所を検索できます。<br>現在、下記の駅周辺の施設に対応しています。エリアは順次拡大予定です。
+        div 対応中の駅（エリア）
+        - stations.each do |station|
+          span.mark.mr-2 = station.name

--- a/app/views/workshops/index.html.slim
+++ b/app/views/workshops/index.html.slim
@@ -1,32 +1,12 @@
-.title
-  h1 SHIGOTOBA
-
-.search-field
-  = form_with scope: :search, url: workshops_path,
-    method: :get, local: true do |form|
-    strong 絞り込み条件
-    div
-      = form.label :station_id, Workshop.human_attribute_name(:station)
-      = form.collection_select(:station_id, Station.all, :id, :name,
-        selected: @search_params[:station_id], include_blank: '選択しない')
-    div
-      = form.label :category, Workshop.human_attribute_name(:category)
-      = form.select :category, Workshop.categories_i18n.invert,
-        selected: @search_params[:category], include_blank: '選択しない'
-    strong こだわり条件
-    div
-      = form.label :wifi, "#{Workshop.human_attribute_name(:wifi)}あり"
-      = form.check_box :wifi, { checked: @search_params[:wifi] == 'true' },
-        true, false
-    div
-      = form.submit '検索する'
-
-.workshops-field
-  - @workshops.each do |workshop|
-    div
-      .info-part
-        h3 = workshop.name
-        div 住所：#{workshop.address}
-        div 最寄駅：#{workshop.station.name}
-      .button-part
-        = link_to '詳細ページ', workshop
+.container
+  = render 'title', stations: @stations
+  .row.mt-5
+    = render 'search_field', search_params: @search_params
+    .workshops-field.col-9.px-5
+      - @workshops.each do |workshop|
+        .card.mb-3.shadow-sm.bg-snow
+          .card-body
+            h4.card-title = workshop.name
+            h6.card-subtitle.mb-2.text-muted = workshop.station.name
+            p.card-text.mb-0 = workshop.address
+            = link_to '詳細ページ', workshop, class: 'btn btn-primary float-right'

--- a/app/views/workshops/show.html.slim
+++ b/app/views/workshops/show.html.slim
@@ -1,29 +1,28 @@
-.title
-  h1 SHIGOTOBA
-.search-field
-.workshop-field
-  h2 = @workshop.name
-  div
-    div 住所
-    div = @workshop.address
-  div
-    div 最寄駅
-    div = @workshop.station.name
-  div
-    div wi-fi有無
-    div = @workshop.wifi ? 'あり' : 'なし'
-  div
-    div 施設タイプ
-    div = @workshop.category_i18n
-  div
-    div 席数
-    div = @workshop.seats_number.presence || '不明'
-  div
-    div 営業時間
-    div = @workshop.opening_time
-  div
-    div 利用料
-    div = @workshop.price
-  div
-    div 特徴
-    div = @workshop.note
+.container
+  = render 'title', stations: @stations
+  .row.mt-5
+    = render 'search_field', search_params: @search_params
+    .workshop-field.col-9.px-5
+      .card.shadow.bg-snow
+        .card-body
+          h2.card-title.mb-4 = @workshop.name
+          h4.card-subtitle.text-muted.mb-3 = @workshop.station.name
+          p.card-text = @workshop.address
+          table.table.table-bordered.my-5
+            tbody
+              tr
+                th[style='width:20%'] = Workshop.human_attribute_name(:category)
+                td[style='width:80%'] = @workshop.category_i18n
+              tr
+                th[style='width:20%'] #{Workshop.human_attribute_name(:wifi)}環境
+                td[style='width:80%'] = @workshop.wifi ? 'あり' : 'なし'
+              tr
+                th[style='width:20%'] = Workshop.human_attribute_name(:seats_number)
+                td[style='width:80%'] = @workshop.seats_number.presence || '不明'
+              tr
+                th[style='width:20%'] = Workshop.human_attribute_name(:opening_time)
+                td[style='width:80%'] = @workshop.opening_time
+              tr
+                th[style='width:20%'] = Workshop.human_attribute_name(:price)
+                td[style='width:80%'] = @workshop.price
+          p.card-text.my-5 = simple_format(@workshop.note)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,6 +14,7 @@ ja:
       workshop: 作業場所
     attributes:
       workshop:
+        id: ID
         name: 施設名称
         category: 業態
         address: 住所


### PR DESCRIPTION
close #17 

# 対応内容
- ユーザー向け画面のデザイン
- 管理側画面（施設一覧、駅一覧）の調整
- 作業場所詳細画面において、一覧画面（トップページ）同様に作業場所検索が行えるようにした。

# 確認内容
- 画面に意図したデザインが施されていることを確認
- 作業場所詳細画面にて作業場所検索が行えることを確認

# 画面
## 作業場所一覧画面（トップページ）
![image](https://user-images.githubusercontent.com/60866281/76821789-4dcb5680-6852-11ea-83fb-4861c2dad890.png)

## 作業場所詳細画面
![image](https://user-images.githubusercontent.com/60866281/76821795-53c13780-6852-11ea-85ac-db080f20e5ae.png)

## 管理側の作業場所一覧画面
![image](https://user-images.githubusercontent.com/60866281/76821803-5a4faf00-6852-11ea-9917-6bb0f0388ed4.png)

