### PR TITLE
DEV-18 ユーザーアカウント作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
     ast (2.4.0)
+    bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
@@ -225,6 +226,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
   enum_help

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# ユーザー登録
+class UsersController < ApplicationController
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to root_path
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# ユーザー
+class User < ApplicationRecord
+  has_secure_password validations: true
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
+end

--- a/app/views/admin/workshops/_form.html.slim
+++ b/app/views/admin/workshops/_form.html.slim
@@ -2,7 +2,7 @@
 
   - if workshop.errors.any?
     ul
-      - @workshop.errors.full_messages.each do |message|
+      - workshop.errors.full_messages.each do |message|
         li
           = message
 

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,0 +1,23 @@
+= form_with model: @user, url: sign_in_path, local: true do |form|
+
+  - if @user.errors.any?
+    - @user.errors.full_messages.each do |message|
+      .alert.alert-warning.m-0 = message
+
+  .container.mt-5.p-5
+    .px-5
+      h1 ユーザー新規登録
+      .form-group
+        = form.label :name, User.human_attribute_name(:name)
+        = form.text_field :name, class: 'form-control'
+      .form-group
+        = form.label :email, User.human_attribute_name(:email)
+        = form.text_field :email, class: 'form-control'
+      .form-group
+        = form.label :password, User.human_attribute_name(:password)
+        = form.text_field :password, class: 'form-control'
+      .form-group
+        = form.label :password_confirmation, User.human_attribute_name(:password_confirmation)
+        = form.text_field :password_confirmation, class: 'form-control'
+      div
+        = form.submit value: '登録する', class: 'btn btn-danger float-right'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,7 @@ ja:
   activerecord:
     models:
       workshop: 作業場所
+      user: ユーザー
     attributes:
       workshop:
         id: ID
@@ -23,7 +24,13 @@ ja:
         opening_time: 営業時間
         price: 利用料
         note: 特徴
-        station: 最寄駅  
+        station: 最寄駅
+      user:
+        name: 名前
+        email: メールアドレス
+        password_digest: パスワード
+        password: パスワード
+        password_confirmation: パスワード（確認）
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   root 'workshops#index'
+
+  get '/sign_in', to: 'users#new'
+  post '/sign_in', to: 'users#create'
+  
   resources :workshops, only: [:index, :show]
   namespace :admin do
     resources :workshops, except: :show

--- a/db/migrate/20200317064950_create_users.rb
+++ b/db/migrate/20200317064950_create_users.rb
@@ -6,5 +6,6 @@ class CreateUsers < ActiveRecord::Migration[6.0]
       t.string :password_digest, null: false, comment: 'パスワード'
       t.timestamps
     end
+    add_index :users, :email, unique: true
   end
 end

--- a/db/migrate/20200317064950_create_users.rb
+++ b/db/migrate/20200317064950_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false, comment: '名前'
+      t.string :email, null: false, comment: 'メールアドレス'
+      t.string :password_digest, null: false, comment: 'パスワード'
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2020_03_17_064950) do
     t.string "password_digest", null: false, comment: "パスワード"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
   create_table "workshops", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_02_021612) do
+ActiveRecord::Schema.define(version: 2020_03_17_064950) do
 
   create_table "stations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false, comment: "駅名"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false, comment: "名前"
+    t.string "email", null: false, comment: "メールアドレス"
+    t.string "password_digest", null: false, comment: "パスワード"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
closed #31 

# 対応内容
- ユーザーアカウントを作成できるようにした
- 新規登録画面作成
- URLは /sign_inとした
- カラムは名前、メールアドレス、パスワード、timestampを用意した
- 名前、メールアドレス、パスワードに対してバリデーションを設定し、ユーザー作成に失敗した場合はエラーメッセージが出力されるようにした。
- パスワードはデータベースに暗号化されて保存されるようにした

# 確認内容
- ユーザーアカウントが作成できること
- ユーザー作成に失敗した場合、エラーメッセージが出力されること

# 画面
## ユーザー新規登録画面
![image](https://user-images.githubusercontent.com/60866281/76917234-259d2f80-6906-11ea-8c2f-b9f4cfb2fc6a.png)
