### PR TITLE
DEV-22 お気に入り一覧画面作成

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-# お気に入り登録・削除
+# お気に入り機能
 class FavoritesController < ApplicationController
+  def index
+    @stations = Station.all
+  end
+
   def create
     @favorite_workshop = Favorite.new(user_id: current_user.id, workshop_id: params[:format])
     if @favorite_workshop.save

--- a/app/views/favorites/index.html.slim
+++ b/app/views/favorites/index.html.slim
@@ -1,0 +1,18 @@
+= render 'workshops/navbar'
+.container
+  = render 'workshops/title', stations: @stations
+  .row.mt-5
+    .col-3.px-3
+      h5 #{current_user.name} さんの
+      h5 お気に入りページ
+    .col-9.px-5
+      - if current_user.workshops.present?
+        - current_user.workshops.each do |workshop|
+          .card.mb-3.shadow-sm.bg-whitesmoke
+            .card-body
+              h4.card-title = workshop.name
+              h6.card-subtitle.mb-2.text-muted = workshop.station.name
+              p.card-text.mb-0 = workshop.address
+              = link_to '詳細ページ', workshop, class: 'btn btn-primary float-right'
+      - else
+        p お気に入りは登録されていません

--- a/app/views/workshops/_navbar.html.slim
+++ b/app/views/workshops/_navbar.html.slim
@@ -1,7 +1,12 @@
-nav.navbar.bg-lightsteelblue.justify-content-end
-  .mr-1
-    = link_to '新規登録', sign_in_path, class: 'btn btn-danger'
-  .ml-1
-    = link_to 'ログイン', login_path, class: 'btn btn-danger'
+- if logged_in?
+  nav.navbar.bg-lightsteelblue.justify-content-end
+    .mr-1
+      = link_to 'お気に入り一覧', favorites_path, class: 'btn btn-warning'
+- else
+  nav.navbar.bg-lightsteelblue.justify-content-end
+    .mr-1
+      = link_to '新規登録', sign_in_path, class: 'btn btn-danger'
+    .ml-1
+      = link_to 'ログイン', login_path, class: 'btn btn-danger'
 - if flash[:notice].present?
   .alert.alert-success.m-0 = flash[:notice]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   post '/login', to: 'sessions#create'
   
   resources :workshops, only: [:index, :show]
-  resources :favorites, only: [:create, :destroy]
+  resources :favorites, only: [:index, :create, :destroy]
   namespace :admin do
     resources :workshops, except: :show
     resources :stations


### PR DESCRIPTION
closed #42 

# 対応内容
- ログインしていればヘッダーにお気に入りボタンが表示されていること
- ログインユーザーに紐づいたお気に入り一覧が表示されること

# 確認内容
- ログイン状態のときにヘッダーにお気に入り一覧ボタンが表示されること
- お気に入り一覧ボタンを押下するとお気に入り一覧画面に移動できること
- ログインユーザーに紐づいたお気に入り一覧が表示されること

# 画面
## お気に入り一覧画面
![image](https://user-images.githubusercontent.com/60866281/77390939-c5612e80-6dda-11ea-8da7-65550a4154d5.png)

